### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Following keyboards are supported.
 - [kinesis](https://github.com/qmk/qmk_firmware/tree/master/keyboards/kinesis)
 - [lets_split](https://github.com/qmk/qmk_firmware/tree/master/keyboards/lets_split)
 - [mint60](https://github.com/qmk/qmk_firmware/tree/master/keyboards/mint60)
-- [kaihi65](https://github.com/qmk/qmk_firmware/tree/master/keyboards/kbdclack/kaishi65)
+- [kaishi65](https://github.com/qmk/qmk_firmware/tree/master/keyboards/kbdclack/kaishi65)
 
 ## Install
 


### PR DESCRIPTION
Fixed typo in README,

`[kaihi65]` should be `[kaishi65]`,

Sorry for not catching it in my initial PR 