### PR TITLE
Improve regexp for comment matching

### DIFF
--- a/keymapviz/__init__.py
+++ b/keymapviz/__init__.py
@@ -119,7 +119,7 @@ class Keymapviz():
                     ret = matchobj[0]
                 return ret
 
-        pattern = r'^[ \t\r\f\v]*?/\*.*?\[keymapviz\].*?\*/\s*?$'
+        pattern = r'^[ \t\r\f\v]*?/\*((?!\*/).)*?\[keymapviz\].*?\*/\s*?$'
         repl = Repl(self.__ascii_art)
         kc = re.sub(pattern, repl.next, self.__keymap_c, flags=re.MULTILINE|re.DOTALL)
         return kc


### PR DESCRIPTION
The proposed change will make it so that the regexp will not match things like
```
/* comment */
dzodz
/* [keymapviz] */
```