### PR TITLE
Add layout for each keyboard in help

### DIFF
--- a/keymapviz/keymapviz.py
+++ b/keymapviz/keymapviz.py
@@ -24,18 +24,35 @@ def split_path(path):
         return [tail]
     return split_path(head) + [tail]
 
+def get_epilog(keyboard_keys):
+    keyboard_layouts_pairs = []
+    for key in keyboard_keys:
+        layout_keys = list(keymapviz.KEYBOARDS[key].ascii_art.keys())
+        keyboard_layouts_pairs.append((key, layout_keys))
+    layouts_dict = dict(keyboard_layouts_pairs)
+
+    keyboard_descriptions = []
+    for key in keyboard_keys:
+        desc = '{} ({})'.format('{:20}'.format(key), ', '.join(layouts_dict[key]))
+        keyboard_descriptions.append(desc)
+
+    header = 'Following keyboards (and layouts) are supported.'
+    keyboard_description = '\n * '.join(keyboard_descriptions)
+    epilog = header + '\n * ' + keyboard_description
+    return epilog
 
 def parse_arg():
-    keyboards = sorted(keymapviz.KEYBOARDS.keys())
+    keyboard_keys = sorted(keymapviz.KEYBOARDS.keys())
     types = list(TYPES.keys())
 
     desc = 'keymap.c visualizer'
+    epilog = get_epilog(keyboard_keys)
     parser = argparse.ArgumentParser(description=desc,
-                                     epilog='Following keyboards are supported.\n * '+'\n * '.join(keyboards),
+                                     epilog=epilog,
                                      formatter_class=argparse.RawTextHelpFormatter)
 
     parser.add_argument('-c', '--config',   type=argparse.FileType('r'), help='configuration file')
-    parser.add_argument('-k', '--keyboard', type=str, choices=keyboards, help='keyboard of keymap.c', metavar='keyboards')
+    parser.add_argument('-k', '--keyboard', type=str, choices=keyboard_keys, help='keyboard of keymap.c', metavar='keyboards')
     parser.add_argument('-l', '--layout',   type=str, help='keyboard layout', metavar='layout')
     parser.add_argument('-o', '--output',   type=str, help='output file name("{}" is replaced index)')
     parser.add_argument('-r', '--replace',  action='store_true', help='replace comment block including "[keymapviz]" with ascii art. (make *.bac)')
@@ -48,7 +65,7 @@ def parse_arg():
     # Search keyboard name in 'keymap_c' path, if '-k' option is empty.
     if arg.keyboard is None:
         path = split_path(os.path.abspath(arg.keymap_c.name))
-        pset = list(set(path) & set(keyboards))  # product set
+        pset = list(set(path) & set(keyboard_keys))  # product set
         if not pset:
             print('Sorry. Please choose your keyboard(-k/--keyboard).', file=sys.stderr)
             sys.exit(1)


### PR DESCRIPTION
Before
```
usage: keymapviz [-h] [-c CONFIG] [-k keyboards] [-o OUTPUT] [-r]
                 [-t {ascii,json,fancy}] [-v]
                 keymap_c

keymap.c visualizer

positional arguments:
  keymap_c              keymap.c file name

optional arguments:
  -h, --help            show this help message and exit
  -c CONFIG, --config CONFIG
                        configuration file
  -k keyboards, --keyboard keyboards
                        keyboard of keymap.c
  -o OUTPUT, --output OUTPUT
                        output file name("{}" is replaced index)
  -r, --replace         replace comment block including "[keymapviz]" with ascii art. (make *.bac)
  -t {ascii,json,fancy}, --type {ascii,json,fancy}
                        type of output(default:ascii)
  -v, --version         show program's version number and exit

Following keyboards are supported.
 * crkbd
 * dactyl_manuform5x6
 * ergo42
 * ergodash
 * ergodone
 * ergodox
 * ergodox_ez
 * fortitude60
 * helix
 * kaishi65
 * kinesis
 * kyria
 * lets_split
 * lily58
 * mint60
 * moonlander
 * sofle
 * sweet16
```

After
```
usage: keymapviz [-h] [-c CONFIG] [-k keyboards] [-l layout] [-o OUTPUT] [-r]
                 [-t {ascii,json,fancy}] [-v]
                 keymap_c

keymap.c visualizer

positional arguments:
  keymap_c              keymap.c file name

optional arguments:
  -h, --help            show this help message and exit
  -c CONFIG, --config CONFIG
                        configuration file
  -k keyboards, --keyboard keyboards
                        keyboard of keymap.c
  -l layout, --layout layout
                        keyboard layout
  -o OUTPUT, --output OUTPUT
                        output file name("{}" is replaced index)
  -r, --replace         replace comment block including "[keymapviz]" with ascii art. (make *.bac)
  -t {ascii,json,fancy}, --type {ascii,json,fancy}
                        type of output(default:ascii)
  -v, --version         show program's version number and exit

Following keyboards (and layouts) are supported.
 * crkbd                (default)
 * dactyl_manuform5x6   (default)
 * ergo42               (default)
 * ergodash             (default, 2u_inner)
 * ergodone             (default)
 * ergodox              (default)
 * ergodox_ez           (default)
 * fortitude60          (default)
 * helix                (default)
 * kaishi65             (default)
 * kinesis              (default)
 * kyria                (default)
 * lets_split           (default)
 * lily58               (default)
 * mint60               (default)
 * moonlander           (default)
 * sofle                (default)
 * sweet16              (default)
```