### PR TITLE
Fix arrows in example config.properties

### DIFF
--- a/config.properties
+++ b/config.properties
@@ -21,9 +21,9 @@ KC_MINS=- _
 KC_EQL== +
 KC_ALGR(KC_5)=€
 KC_SLSH=/ ?
-KC_COMM=, >
+KC_COMM=, <
 KC_ASTR=*
-KC_DOT=. <
+KC_DOT=. >
 KC_BSLS=\ |
 KC_QUOT=' "
 KC_SCLN=; :

--- a/config.properties
+++ b/config.properties
@@ -27,3 +27,5 @@ KC_DOT=. >
 KC_BSLS=\ |
 KC_QUOT=' "
 KC_SCLN=; :
+KC_QUES=?
+KC_COLN=:


### PR DESCRIPTION
KC_COMM is , and <
KC_DOT is . and >

Also added a couple symbols missing from the list.