### PR TITLE
Fix stripping of enclosing parentheses

### DIFF
--- a/keymapviz/__init__.py
+++ b/keymapviz/__init__.py
@@ -80,7 +80,7 @@ class Keymapviz():
             r'\s*(\w+(?<rec>\((?:[^()]|(?&rec))*\))*)\s*,?'
         )
         keymaps = keymap_regexp.findall(src)
-        keymaps = [_.lstrip('(').rstrip(')') for _ in keymaps]
+        keymaps = [re.sub(r"^\(?(.*)\)?$", r"\1", _) for _ in keymaps]
         keymaps = [[__[0] for __ in keycode_regexp.findall(_)] for _ in keymaps]
         return keymaps
 


### PR DESCRIPTION
The current code strips _all_ surrounding parentheses, while only the outermost should be stripped. This commit changes this.

Closes https://github.com/yskoht/keymapviz/issues/91